### PR TITLE
Seph/byname

### DIFF
--- a/osquery-packer.py
+++ b/osquery-packer.py
@@ -6,10 +6,10 @@ import json
 import os
 import sys
 
+
 def is_valid_input_dir(parser, arg):
     if not os.path.isdir(arg):
         parser.error("The input directory %s does not exist!" % arg)
-
     return arg
 
 
@@ -18,16 +18,14 @@ def parse_args():
     parser.add_argument('-i', dest='input', required=True,
                         type=lambda x: is_valid_input_dir(parser, x),
                         help='Input Directory')
-
     parser.add_argument('-o', dest='output', required=True,
-                            help='Output Pack File')
-
+                        help='Output Pack File')
     parser.add_argument('-r', dest='readme', required=False,
                         help='Output Readme File (if present)')
 
-    
     args = parser.parse_args()
     return args
+
 
 def json_load(filepath):
     filedata = {}
@@ -44,12 +42,12 @@ def json_load(filepath):
 def merge_json_files(rootdir, files):
     data = {}
     for f in [f for f in files if f.endswith('.json')]:
-        filepath=os.path.join(rootdir, f)
+        filepath = os.path.join(rootdir, f)
         logger.debug("Parsing %s" % filepath)
         data.update(json_load(filepath))
     return data
 
-    
+
 # parse the input directory, and build a database of all the
 # hashses. These will be merged at a later step.
 def walk_input_dir(dir):
@@ -68,7 +66,7 @@ def walk_input_dir(dir):
             if queryname in queries:
                 logger.critical("Duplicate query name %s" % queryname)
                 sys.exit(1)
-            
+
             queries[queryname] = queryfile
             confdb[queryfile] = {
                 'query': open(queryfile).read().lstrip().rstrip()
@@ -93,8 +91,9 @@ def merger(confdb, path):
 
 def generate_readme(fh, pack_data):
     # Vague style guidance from https://osquery.io/schema/packs/
-    # github markdown requires header rows. If we want to remove them, need html tables.
-    format_str='''
+    # github markdown requires header rows. If we want to remove them,
+    # need html tables.
+    format_str = '''
 | {name} | {description} |
 | ------ | ------ |
 | Value | {value} |
@@ -107,22 +106,23 @@ def generate_readme(fh, pack_data):
 '''
     for qname, qdata in pack_data['queries'].items():
         fh.write(format_str.format(
-            name = qname,
-            description = qdata['description'],
-            query = qdata['query'],
-            interval = qdata['interval'],
-            platform = qdata.get('platform', 'all'),
-            value = qdata['value']
+            name=qname,
+            description=qdata['description'],
+            query=qdata['query'],
+            interval=qdata['interval'],
+            platform=qdata.get('platform', 'all'),
+            value=qdata['value']
         ))
+
 
 def main():
     args = parse_args()
-    queries, confdb =  walk_input_dir(args.input)
+    queries, confdb = walk_input_dir(args.input)
 
     pack_data = {
         'queries': {},
     }
-    
+
     for name, path in queries.iteritems():
         data = merger(confdb, path)
         logger.debug("Found query {0}, defined as {1}".format(name, data))
@@ -137,16 +137,14 @@ def main():
                   sort_keys=True,
                   separators=(',', ': '))
         fh.write("\n")
-    
 
     if args.readme:
         with open(args.readme, 'w') as fh:
             generate_readme(fh, pack_data)
-          
 
-logger = logging.getLogger('osquery-packer')
-logging.basicConfig()
-logger.setLevel(logging.INFO)
 
 if __name__ == "__main__":
+    logger = logging.getLogger('osquery-packer')
+    logging.basicConfig()
+    logger.setLevel(logging.INFO)
     main()


### PR DESCRIPTION
The original version of this used query as uniqueness constraint. Things were indexed by query. This proved hard to scale to supporting snapshot and non-snapshots. (which need identical queries)
    
This removes the entire `queries` hash, and moves all the rollup to the `confdb` one, and moves the uniqueness over to the name.
    
This has some odd effects, but I think it's a bit cleaner
